### PR TITLE
move angular-mocks to devDependencies

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -11,7 +11,9 @@
     "url": "git://github.com/jacobscarter/angular-cron-jobs.git"
   },
   "dependencies": {
-    "angular": "*",
+    "angular": "*"
+  },
+  "devDependencies": {
     "angular-mocks": "*"
   },
   "ignore": [


### PR DESCRIPTION
angular-mocks requires a specific angular version. If you don't need it for production, put it in the dev dependencies, because otherwise every project requires the same angular version as angular-mocks = bad.